### PR TITLE
Fix system_instruction not being provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ prompt = ("Hi, can you create a 3d rendered image of a pig "*
 
 response = generate_content(
     secret_key,
-    "gemini-2.0-flash-exp-image-generation",
+    "gemini-2.5-flash-preview-05-20",
     prompt;
     config
 );
@@ -148,7 +148,7 @@ Edit image with Gemini:
 ```julia
 image_path = "gemini-native-image.png"
 
-model = "gemini-2.0-flash-exp-image-generation"
+model = "gemini-2.5-flash-preview-05-20"
 prompt = "Make the pig a llama"
 response = generate_content(
     secret_key,

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -2,9 +2,16 @@
 function _build_request_body(
     conversation::Vector{Dict{Symbol,Any}}, config::GenerateContentConfig
 )
-    body = Dict(
-        "contents" => conversation, "generationConfig" => _build_generation_config(config)
-    )
+    body = Dict{String,Any}()
+    
+    # Add system instruction if provided
+    if config.system_instruction !== nothing
+        body["systemInstruction"] = _format_system_instruction(config.system_instruction)
+    end
+    
+    # Add required fields
+    body["contents"] = conversation
+    body["generationConfig"] = _build_generation_config(config)
 
     # Add optional fields
     config.tools !== nothing && (body["tools"] = config.tools)
@@ -12,6 +19,14 @@ function _build_request_body(
     config.cached_content !== nothing && (body["cachedContent"] = config.cached_content)
 
     return body
+end
+
+function _format_system_instruction(instruction::String)
+    return Dict(
+        "parts" => [
+            Dict("text" => instruction)
+        ]
+    )
 end
 
 function _convert_contents(contents::AbstractVector)


### PR DESCRIPTION
Fixes https://github.com/tylerjthomas9/GoogleGenAI.jl/issues/25

CHANGES:
- I've added proper passthrough of the system_instruction as per the docs: https://ai.google.dev/gemini-api/docs/text-generation

```
curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$GEMINI_API_KEY" \
  -H 'Content-Type: application/json' \
  -d '{
    "system_instruction": {
      "parts": [
        {
          "text": "You are a cat. Your name is Neko."
        }
      ]
    },
    "contents": [
      {
        "parts": [
          {
            "text": "Hello there"
          }
        ]
      }
    ]
  }'
  ```
- Updated flash-exp-image-generation reference in README and tests to flash-2.5-preview-05-20, because the former has been discontinued (the API said so)
- Added tests for newly added function (just small utils, feel free to scrap it)

I cannot run your tests fully since I'm geofenced, but all the calls that I could run passed.

  
  