### PR TITLE
Add multiple image support with clean API

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -751,10 +751,11 @@ Generate streaming content using automatic API key detection from environment va
 function generate_content_stream(
     model_name::String,
     conversation::Vector{Dict{Symbol,Any}};
+    image_path::String="",
     config=GenerateContentConfig(),
 )
     return generate_content_stream(
-        GoogleProvider(), model_name, conversation; config
+        GoogleProvider(), model_name, conversation; image_path, config
     )
 end
 
@@ -777,9 +778,10 @@ Generate streaming content using automatic API key detection from environment va
 function generate_content_stream(
     model_name::String,
     prompt::String;
+    image_path::String="",
     config=GenerateContentConfig(),
 )
-    return generate_content_stream(GoogleProvider(), model_name, prompt; config)
+    return generate_content_stream(GoogleProvider(), model_name, prompt; image_path, config)
 end
 
 """

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -390,6 +390,7 @@ function generate_content_stream(
     provider::AbstractGoogleProvider,
     model_name::String,
     conversation::Vector{Dict{Symbol,Any}};
+    image_path::String,
     config::GenerateContentConfig=GenerateContentConfig(),
 )
     endpoint = "models/$model_name:streamGenerateContent"
@@ -589,10 +590,11 @@ function generate_content_stream(
     api_key::String,
     model_name::String,
     conversation::Vector{Dict{Symbol,Any}};
+    image_path::String,
     config=GenerateContentConfig(),
 )
     return generate_content_stream(
-        GoogleProvider(; api_key), model_name, conversation; config
+        GoogleProvider(; api_key), model_name, conversation; image_path, config
     )
 end
 
@@ -600,12 +602,14 @@ function generate_content_stream(
     provider::AbstractGoogleProvider,
     model_name::String,
     prompt::String;
+    image_path::String,
     config=GenerateContentConfig(),
 )
     return generate_content_stream(
         provider,
         model_name,
         [Dict(:role => "user", :parts => [Dict("text" => prompt)])];
+        image_path,
         config,
     )
 end
@@ -614,12 +618,14 @@ function generate_content_stream(
     api_key::String,
     model_name::String,
     prompt::String;
+    image_path::String,
     config=GenerateContentConfig(),
 )
     return generate_content_stream(
         GoogleProvider(; api_key),
         model_name,
         [Dict(:role => "user", :parts => [Dict("text" => prompt)])];
+        image_path,
         config,
     )
 end

--- a/src/generate.jl
+++ b/src/generate.jl
@@ -465,14 +465,14 @@ function generate_content_stream(
 
                             # Extract the text from the JSON structure
                             if !haskey(chunk_data, :candidates) ||
-                                isempty(chunk_data.candidates)
+                               isempty(chunk_data.candidates)
                                 continue
                             end
 
                             content = get(chunk_data.candidates[1], :content, nothing)
                             if content === nothing ||
-                                !haskey(content, :parts) ||
-                                isempty(content.parts)
+                               !haskey(content, :parts) ||
+                               isempty(content.parts)
                                 continue
                             end
 


### PR DESCRIPTION
This PR introduces a unified approach to handling multiple images in `generate_content` functions while maintaining backward compatibility.

## Changes

### New `images` Parameter
Added `images::AbstractVector=NamedTuple[]` parameter that accepts named tuples with:
- `(path="image.jpg",)` - file path (mime type auto-detected)
- `(data="base64data", mime_type="image/jpeg")` - base64 data with explicit mime type
- `(path="image.png", mime_type="image/png")` - file path with mime type override

### Simplified API
- Removed redundant `image_paths`, `image_base64_list`, and `image_mime_types` parameters
- Kept `image_path` for single image backward compatibility
- Consolidated image handling logic in `_image_inline_parts` helper

### Usage Examples
```julia
# Multiple images from files
generate_content(model, prompt; images=[
    (path="photo1.jpg",),
    (path="diagram.png",)
])

# Mixed file paths and base64 data
generate_content(model, prompt; images=[
    (path="photo.jpg",),
    (data="iVBORw0KGgoAAAA...", mime_type="image/png")
])

# Single image (backward compatible)
generate_content(model, prompt; image_path="photo.jpg")
```

## Benefits
- **Cleaner API**: Single `images` parameter instead of multiple arrays
- **Type Safety**: Named tuples provide clear structure
- **Flexibility**: Mix file paths and base64 data in one call
- **Backward Compatible**: Existing `image_path` usage unchanged
- **DRY**: Eliminated code duplication in image handling